### PR TITLE
Use wildcard import for top-level Phaser name

### DIFF
--- a/scaffolding/clean/angular/ts/app.component.ts
+++ b/scaffolding/clean/angular/ts/app.component.ts
@@ -2,7 +2,7 @@ import { Component, viewChild } from '@angular/core';
 import { PhaserGame } from './phaser-game.component';
 import { CommonModule } from '@angular/common';
 import { EventBus } from '../game/EventBus';
-import Phaser from 'phaser';
+import * as Phaser from 'phaser';
 
 @Component({
     selector: 'app-root',

--- a/scaffolding/clean/nextjs/ts/App.tsx
+++ b/scaffolding/clean/nextjs/ts/App.tsx
@@ -1,5 +1,6 @@
 import { useRef } from 'react';
 import { IRefPhaserGame, PhaserGame } from './PhaserGame';
+import * as Phaser from 'phaser';
 
 function App()
 {

--- a/scaffolding/clean/react/js/App.jsx
+++ b/scaffolding/clean/react/js/App.jsx
@@ -1,6 +1,6 @@
 import { useRef } from 'react';
 
-import Phaser from 'phaser';
+import * as Phaser from 'phaser';
 import { PhaserGame } from './PhaserGame';
 
 function App ()

--- a/scaffolding/clean/react/ts/App.tsx
+++ b/scaffolding/clean/react/ts/App.tsx
@@ -1,5 +1,6 @@
 import { useRef } from 'react';
 import { IRefPhaserGame, PhaserGame } from './PhaserGame';
+import * as Phaser from 'phaser';
 
 function App()
 {

--- a/scaffolding/clean/remix/ts/app.client.tsx
+++ b/scaffolding/clean/remix/ts/app.client.tsx
@@ -1,5 +1,6 @@
 import { useRef } from 'react';
 import { IRefPhaserGame, PhaserGame } from './PhaserGame';
+import * as Phaser from 'phaser';
 
 function App()
 {

--- a/scaffolding/clean/solid/ts/App.tsx
+++ b/scaffolding/clean/solid/ts/App.tsx
@@ -1,6 +1,6 @@
 import type { IRefPhaserGame } from './PhaserGame';
 import { PhaserGame } from './PhaserGame';
-import Phaser from 'phaser';
+import * as Phaser from 'phaser';
 
 const App = () => {
     

--- a/scaffolding/clean/vue/js/App.vue
+++ b/scaffolding/clean/vue/js/App.vue
@@ -1,5 +1,5 @@
 <script setup>
-import Phaser from 'phaser';
+import * as Phaser from 'phaser';
 import { ref, toRaw } from 'vue';
 import PhaserGame from './PhaserGame.vue';
 

--- a/scaffolding/clean/vue/ts/App.vue
+++ b/scaffolding/clean/vue/ts/App.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import Phaser from 'phaser';
+import * as Phaser from 'phaser';
 import { ref, toRaw } from 'vue';
 import PhaserGame from './PhaserGame.vue';
 

--- a/scaffolding/demo/coin-clicker/src/main.js
+++ b/scaffolding/demo/coin-clicker/src/main.js
@@ -4,6 +4,7 @@ import { Game } from 'phaser';
 import { GameOver } from './scenes/GameOver';
 import { MainMenu } from './scenes/MainMenu';
 import { Preloader } from './scenes/Preloader';
+import * as Phaser from 'phaser';
 
 //  Find out more information about the Game Config at: https://newdocs.phaser.io/docs/3.70.0/Phaser.Types.Core.GameConfig
 const config = {

--- a/scaffolding/demo/coin-clicker/src/scenes/ClickerGame.js
+++ b/scaffolding/demo/coin-clicker/src/scenes/ClickerGame.js
@@ -1,4 +1,5 @@
 import { Scene } from 'phaser';
+import * as Phaser from 'phaser';
 
 export class ClickerGame extends Scene
 {

--- a/scaffolding/demo/memory-card-game/src/Play.js
+++ b/scaffolding/demo/memory-card-game/src/Play.js
@@ -1,5 +1,5 @@
 import { createCard } from './createCard';
-import Phaser from 'phaser';
+import * as Phaser from 'phaser';
 
 /**
  * Card Memory Game by Francisco Pereira (Gammafp)

--- a/scaffolding/demo/memory-card-game/src/Preloader.js
+++ b/scaffolding/demo/memory-card-game/src/Preloader.js
@@ -1,4 +1,4 @@
-import Phaser from 'phaser';
+import * as Phaser from 'phaser';
 
 export class Preloader extends Phaser.Scene
 {

--- a/scaffolding/demo/memory-card-game/src/createCard.js
+++ b/scaffolding/demo/memory-card-game/src/createCard.js
@@ -1,3 +1,5 @@
+import * as Phaser from 'phaser';
+
 /**
  * Create a card game object
  */

--- a/scaffolding/demo/memory-card-game/src/main.js
+++ b/scaffolding/demo/memory-card-game/src/main.js
@@ -1,6 +1,6 @@
 import { Preloader } from './Preloader';
 import { Play } from './Play';
-import Phaser from 'phaser';
+import * as Phaser from 'phaser';
 
 const config = {
     title: 'Card Memory Game',

--- a/scaffolding/demo/phasers-revenge/src/gameobjects/Bullet.js
+++ b/scaffolding/demo/phasers-revenge/src/gameobjects/Bullet.js
@@ -4,7 +4,7 @@ export class Bullet extends GameObjects.Image
 {
     speed;
     flame;
-    end_direction = new Math.Vector2(0, 0);
+    end_direction = new PhaserMath.Vector2(0, 0);
 
     constructor(scene, x, y) {
         super(scene, x, y, "bullet");

--- a/scaffolding/demo/phasers-revenge/src/gameobjects/Bullet.js
+++ b/scaffolding/demo/phasers-revenge/src/gameobjects/Bullet.js
@@ -1,4 +1,4 @@
-import { GameObjects, Math } from "phaser";
+import { GameObjects, Math as PhaserMath } from "phaser";
 
 export class Bullet extends GameObjects.Image
 {
@@ -8,7 +8,7 @@ export class Bullet extends GameObjects.Image
 
     constructor(scene, x, y) {
         super(scene, x, y, "bullet");
-        this.speed = Phaser.Math.GetSpeed(450, 1);
+        this.speed = PhaserMath.GetSpeed(450, 1);
         this.postFX.addBloom(0xffffff, 1, 1, 2, 1.2);
         // Default bullet (player bullet)
         this.name = "bullet";

--- a/scaffolding/demo/phasers-revenge/src/main.js
+++ b/scaffolding/demo/phasers-revenge/src/main.js
@@ -5,6 +5,7 @@ import { HudScene } from "./scenes/HudScene";
 import { MainScene } from "./scenes/MainScene";
 import { MenuScene } from "./scenes/MenuScene";
 import { SplashScene } from "./scenes/SplashScene";
+import * as Phaser from 'phaser';
 
 // More information about config: https://newdocs.phaser.io/docs/3.70.0/Phaser.Types.Core.GameConfig
 const config = {

--- a/scaffolding/demo/phasers-revenge/src/preloader.js
+++ b/scaffolding/demo/phasers-revenge/src/preloader.js
@@ -1,3 +1,5 @@
+import * as Phaser from 'phaser';
+
 // Class to preload all the assets
 // Remember you can load this assets in another scene if you need it
 export class Preloader extends Phaser.Scene {


### PR DESCRIPTION
These changes are meant to address #9. Although the original message in the issue says that the package.json should be updated for Phaser v4, that does not apply to this repo.

Instead, there was another issue that came up related to Phaser v4 regarding how it does not provide a global import. As a result, references to `Phaser` throughout the scaffolding templates will result in the error I reported in the issue. Also, I am very certain [this Discord comment](https://discord.com/channels/244245946873937922/636143808769163274/1495118775966634014) is referring to the same issue.

The simplest way to resolve the `Uncaught ReferenceError` is for the template files to have `import * as Phaser from 'phaser';` so the original content can be retained.

I only changed a file to refer to `Phaser.Math` as `PhaserMath` with an accompanying imported alias so that `Math` would still be available.

Please review this **very carefully**. Let me know the best way to test the changes. I believe it's very possible to refer to my local project instead of the NPM project when using `npm create` or something similar...

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches many starter templates and demo entrypoints; while changes are mostly import rewrites, incorrect module interop or tree-shaking differences could break generated projects across bundlers.
> 
> **Overview**
> Switches scaffolding templates (Angular/React/Next/Remix/Solid/Vue) and multiple demo entrypoints to use a namespace import (`import * as Phaser from 'phaser'`) so existing `Phaser.*` references work with module-only Phaser builds.
> 
> In `phasers-revenge`, adjusts `Bullet` to avoid shadowing the global `Math` by aliasing the Phaser math import to `PhaserMath` and updating usages accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e29cb61bcf870da12fd89b294a20286ae31b248. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->